### PR TITLE
feat(db): New indexes for better performance

### DIFF
--- a/packages/db/prisma/migrations/20231229083158_new_hash_indexes/migration.sql
+++ b/packages/db/prisma/migrations/20231229083158_new_hash_indexes/migration.sql
@@ -1,0 +1,29 @@
+-- DropIndex
+DROP INDEX "Inscription_outpoint_idx";
+
+-- AlterTable
+ALTER TABLE "Inscription" ALTER COLUMN "mimeSubtype" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Output" ALTER COLUMN "spent" SET DEFAULT false;
+
+-- CreateIndex
+CREATE INDEX "Inscription_inscriptionId_idx" ON "Inscription" USING HASH ("inscriptionId");
+
+-- CreateIndex
+CREATE INDEX "Inscription_outpoint_idx" ON "Inscription" USING HASH ("outpoint");
+
+-- CreateIndex
+CREATE INDEX "Output_voutTxid_idx" ON "Output" USING HASH ("voutTxid");
+
+-- CreateIndex
+CREATE INDEX "Output_vinBlockHeight_idx" ON "Output"("vinBlockHeight");
+
+-- CreateIndex
+CREATE INDEX "Output_vinTxid_idx" ON "Output" USING HASH ("vinTxid");
+
+-- CreateIndex
+CREATE INDEX "Output_addresses_idx" ON "Output" USING GIN ("addresses" array_ops);
+
+-- CreateIndex
+CREATE INDEX "Output_spent_idx" ON "Output"("spent");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -39,7 +39,10 @@ model Output {
 
   @@index([voutBlockHeight])
   @@unique([voutTxid, voutTxIndex])
+  @@index([voutTxid, voutTxIndex], type: Hash)
+  @@index([vinBlockHeight])
   @@unique([vinTxid, vinTxIndex])
+  @@index([vinTxid, vinTxIndex], type: Hash)
   @@index([addresses(ops:ArrayOps)], type: Gin)
   @@index([spent])
 }
@@ -78,12 +81,11 @@ model Inscription {
   @@index(inscriptionId, type: Hash)
   @@index(height)
   @@index(number)
-  @@index(outpoint)
+  @@index(outpoint, type: Hash)
   @@index(sat)
   @@index(mimeType)
   @@index(mimeSubtype)
   @@index(mediaType)
-
 }
 
 model MediaContent {

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -33,13 +33,15 @@ model Output {
   vinTxid           String?
   vinTxIndex        Int?
   
-  spent             Boolean               @default(true)
+  spent             Boolean               @default(false)
 
   inscriptions      Inscription[]
 
   @@index([voutBlockHeight])
   @@unique([voutTxid, voutTxIndex])
   @@unique([vinTxid, vinTxIndex])
+  @@index([addresses(ops:ArrayOps)], type: Gin)
+  @@index([spent])
 }
 
 model Inscription {
@@ -51,7 +53,7 @@ model Inscription {
   owner             String?
   sat               BigInt
   mimeType          String
-  mimeSubtype       String
+  mimeSubtype       String?
   mediaType         String
   mediaCharset      String
   // Media Size in bytes. Int4 is sufficient, should not exceed 2GB.
@@ -73,6 +75,7 @@ model Inscription {
   meta              Json?
   ometa             Json?
 
+  @@index(inscriptionId, type: Hash)
   @@index(height)
   @@index(number)
   @@index(outpoint)

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -39,10 +39,10 @@ model Output {
 
   @@index([voutBlockHeight])
   @@unique([voutTxid, voutTxIndex])
-  @@index([voutTxid, voutTxIndex], type: Hash)
+  @@index([voutTxid], type: Hash)
   @@index([vinBlockHeight])
   @@unique([vinTxid, vinTxIndex])
-  @@index([vinTxid, vinTxIndex], type: Hash)
+  @@index([vinTxid], type: Hash)
   @@index([addresses(ops:ArrayOps)], type: Gin)
   @@index([spent])
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- Makes `mimeSubtype` nullable on Inscriptions table, as it can be blank
- Set default for `spent` in Outputs table to `false`
- Add new GIN Index on `addresses` in Outputs table
- Add new index on `spent` in Outputs table
- Add new Hash indexes on `inscriptionId` and `outpoint` in Inscriptions table for some O(1) goodness, since queries are all `=`
- Add new Hash indexes on `voutTxid` and `vinTxid` in Outputs table, for potentially better performance. Multi-column hash indexes are not possible, or it would have been better.
- The above might all slow down INSERT slightly, but should improve querying performance

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes ORD-<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes ORD-

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] No console errors on web
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*

<!--
* If applicable
-->
